### PR TITLE
PAAS-183: Update to curator 2.12.0 and don't serialize enabled flag

### DIFF
--- a/router/http/src/main/scala/io/buoyant/router/http/MethodTenantHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/MethodTenantHostIdentifier.scala
@@ -4,8 +4,7 @@ import com.twitter.finagle.{Dtab, Path}
 import com.twitter.finagle.buoyant.Dst
 import com.twitter.finagle.http.{Request, Version}
 import com.twitter.util.Future
-import io.buoyant.router.RoutingFactory
-import io.buoyant.router.RoutingFactory.{IdentifiedRequest, RequestIdentification, UnidentifiedRequest}
+import io.buoyant.router.RoutingFactory.{IdentifiedRequest, Identifier, RequestIdentification, UnidentifiedRequest}
 
 object MethodTenantHostIdentifier {
 
@@ -14,14 +13,14 @@ object MethodTenantHostIdentifier {
   def mk(
     prefix: Path,
     baseDtab: () => Dtab = () => Dtab.base
-  ): RoutingFactory.Identifier[Request] = MethodTenantHostIdentifier(prefix, baseDtab, TenantHeader)
+  ): Identifier[Request] = MethodTenantHostIdentifier(prefix, baseDtab, TenantHeader)
 }
 
 case class MethodTenantHostIdentifier(
   prefix: Path,
   baseDtab: () => Dtab = () => Dtab.base,
   tenantHeader: String
-) extends RoutingFactory.Identifier[Request] {
+) extends Identifier[Request] {
 
   private[this] def mkPath(path: Path): Dst.Path =
     Dst.Path(prefix ++ path, baseDtab(), Dtab.local)


### PR DESCRIPTION
The actual dependency update was done in a previous branch.
That change is already part of 1.1.0-medallia-release.
You can see it here(https://github.com/medallia/linkerd/blob/1.1.0-medallia-release/project/Deps.scala#L61)

After we merge this patch, I'm planning to make this the new official image and ask services (titan, orch, lucene, etc.) to start the adoption.