### PR TITLE
PAAS-352: Add replacing namer

### DIFF
--- a/namer/curatorsd/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
+++ b/namer/curatorsd/src/main/resources/META-INF/services/io.buoyant.namer.NamerInitializer
@@ -1,1 +1,2 @@
 com.medallia.l5d.curatorsd.namer.CuratorSDInitializer
+com.medallia.l5d.namer.ReplacingNamerInitializer

--- a/namer/curatorsd/src/main/scala/com/medallia/l5d/namer/ReplacingNamer.scala
+++ b/namer/curatorsd/src/main/scala/com/medallia/l5d/namer/ReplacingNamer.scala
@@ -1,0 +1,18 @@
+package com.medallia.l5d.namer
+
+import com.twitter.finagle.{Name, NameTree, Namer, Path}
+import com.twitter.util.Activity
+
+import scala.util.matching.Regex
+
+class ReplacingNamer(matchingRegex: Regex, replacement: String) extends Namer {
+
+  override def lookup(path: Path): Activity[NameTree[Name]] = {
+    path.showElems.last match {
+      case matchingRegex(_*) =>
+        val elems: Seq[String] = path.showElems.init :+ replacement
+        Activity.value(NameTree.Leaf(Name(Path.Utf8(elems: _*))))
+      case _ => Activity.value(NameTree.Leaf(Name(path)))
+    }
+  }
+}

--- a/namer/curatorsd/src/main/scala/com/medallia/l5d/namer/ReplacingNamerInitializer.scala
+++ b/namer/curatorsd/src/main/scala/com/medallia/l5d/namer/ReplacingNamerInitializer.scala
@@ -1,0 +1,26 @@
+package com.medallia.l5d.namer
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.twitter.finagle.Stack.Params
+import com.twitter.finagle.{Namer, Path}
+import io.buoyant.namer.{NamerConfig, NamerInitializer}
+
+class ReplacingNamerInitializer extends NamerInitializer {
+  override val configId = "com.medallia.l5d.replacing"
+  val configClass = classOf[ReplacingNamerConfig]
+}
+
+case class ReplacingNamerConfig(
+  pattern: String,
+  replace: String
+) extends NamerConfig {
+  assert(pattern != null)
+  assert(replace != null)
+
+  @JsonIgnore
+  override def defaultPrefix: Path =
+    throw new IllegalArgumentException("The 'prefix' property is required for the com.medallia.l5d.replacing namer.")
+
+  @JsonIgnore
+  override protected def newNamer(params: Params): Namer = new ReplacingNamer(pattern.r, replace)
+}

--- a/namer/curatorsd/src/test/scala/com/medallia/l5d/namer/ReplacingNamerTest.scala
+++ b/namer/curatorsd/src/test/scala/com/medallia/l5d/namer/ReplacingNamerTest.scala
@@ -1,0 +1,28 @@
+package com.medallia.l5d.namer
+
+import com.twitter.finagle.{Name, NameTree, Namer, Path}
+import io.buoyant.test.FunSuite
+
+class ReplacingNamerTest extends FunSuite {
+
+  def assertDelegates(from: String, to: String)(implicit namer: Namer) = {
+    val NameTree.Leaf(Name.Path(result)) = namer.lookup(Path.read(from)).sample()
+    assert(result == Path.read(to))
+  }
+
+  test("matches regex") {
+    implicit val namer = new ReplacingNamer("th.ee".r, "success")
+    assertDelegates("/one/two/three", "/one/two/success")
+  }
+
+  test("doesn't match regex") {
+    implicit val namer = new ReplacingNamer("at.*ee".r, "success")
+    assertDelegates("/one/two/three", "/one/two/three")
+  }
+
+  test("only matches last element") {
+    implicit val namer = new ReplacingNamer("elem".r, "success")
+    assertDelegates("/elem/elem/elem", "/elem/elem/success")
+  }
+
+}

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.1.2-medallia-1.6.1"
+  val headVersion = "1.1.2-medallia-1.7.0"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
New namer that allows to replace the last element in the canonical path, if it matches a given regex. 
This is going to be used to redirect all api.medallia.com call to ApiGateway service name.