### PR TITLE
MSF-13: Ability to specify a default tenant for outgoing requests

### DIFF
--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/EnvTenantHostIdentifierConfig.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/EnvTenantHostIdentifierConfig.scala
@@ -18,10 +18,11 @@ object EnvTenantHostIdentifierConfig {
 }
 
 class EnvTenantHostIdentifierConfig extends HttpIdentifierConfig {
+  val defaultTenant: Option[String] = None
 
   @JsonIgnore
   override def newIdentifier(
     prefix: Path,
     baseDtab: () => Dtab = () => Dtab.base
-  ) = EnvTenantHostIdentifier.mk(prefix, baseDtab)
+  ) = EnvTenantHostIdentifier.mk(prefix, baseDtab, defaultTenant)
 }

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.1.2-medallia-1.7.1"
+  val headVersion = "1.1.2-medallia-1.7.2"
 
   object Git {
     def git(arg: String, args: String*) = Process("git" +: arg +: args)


### PR DESCRIPTION
Requested by chatgrid, so they don't have to inject a special header on all their clients.