### PR TITLE
MSF-9: Allow service discovery to select http / https endpoints

### DIFF
--- a/namer/curatorsd/src/main/scala/com/medallia/l5d/curatorsd/namer/CuratorSDNamer.scala
+++ b/namer/curatorsd/src/main/scala/com/medallia/l5d/curatorsd/namer/CuratorSDNamer.scala
@@ -15,7 +15,7 @@ import scala.collection.JavaConverters._
  * The curator namer takes Paths of the form
  *
  * {{{
- * /#/com.medallia.curatorsd/environment/tenant/service
+ * /#/com.medallia.curatorsd/environment/tenant/service/protocol
  * }}}
  *
  * and returns a dynamic representation of the resolution of the path into a
@@ -27,31 +27,27 @@ class CuratorSDNamer(zkConnectStr: String, backwardsCompatibility: Option[String
 
   private val serviceDiscoveryInfo = CuratorSDCommon.createServiceDiscovery(zkConnectStr, backwardsCompatibility)
 
-  private def instanceToAddress(instance: ServiceInstance[ServiceInstanceInfo]): Address = {
-    val address = instance.getAddress
-    val port = instance.getPort
-    if (address != null && port != null) {
-      Address(address, port)
-    } else {
-      val url = new URL(instance.getUriSpec.build())
-      Address(url.getHost, url.getPort) // TODO (future) support https and path
-    }
-  }
-
-  private def getAddress(instances: Iterable[ServiceInstance[ServiceInstanceInfo]]): Addr = {
-    val addrs = instances.map(instanceToAddress).toStream.distinct
-    log.info("Binding to addresses %s", addrs)
-    Addr.Bound(addrs.toSet, Addr.Metadata.empty)
+  private def getAddress(instances: Iterable[ServiceInstance[ServiceInstanceInfo]], protocol: String): Addr = {
+    val addrs = instances
+                  .map(instance => new URL(instance.getUriSpec.build()))
+                  .filter(url => url.getProtocol() == protocol)
+                  .map(url => Address(url.getHost, url.getPort))
+                  .filter()
+                  .toStream
+                  .distinct
+    log.info("Binding to addresses %s protocol %s", addrs, protocol)
+    val metadata = Addr.Metadata(("ssl", protocol == "https"))
+    Addr.Bound(addrs.toSet, metadata)
   }
 
   override def lookup(path: Path): Activity[NameTree[Name]] = {
     log.info("Binding for path %s", path)
 
     path match {
-      case Path.Utf8(environment, tenant, serviceName) =>
+      case Path.Utf8(environment, tenant, serviceName, protocol) =>
         val serviceId = new ServiceId(serviceName, tenant, CuratorSDCommon.fromOptionalPathField(environment).orNull)
 
-        log.info(s"Looking up %s", serviceId)
+        log.info(s"Looking up %s, protocol: %s", serviceId, protocol)
 
         val addrInit = getAddress(serviceDiscoveryInfo.serviceDiscovery.lookupAll(serviceId).asScala)
         val addrVar = Var.async(addrInit) { update =>
@@ -74,7 +70,7 @@ class CuratorSDNamer(zkConnectStr: String, backwardsCompatibility: Option[String
         }
         Activity.value(NameTree.Leaf(Name.Bound(addrVar, path, path)))
       case _ =>
-        Activity.exception(new IllegalArgumentException(s"Expected curator namer format: /environment/tenant/serviceName, got $path"))
+        Activity.exception(new IllegalArgumentException(s"Expected curator namer format: /environment/tenant/serviceName/protocol, got $path"))
     }
   }
 

--- a/namer/curatorsd/src/main/scala/com/medallia/l5d/curatorsd/namer/CuratorSDNamer.scala
+++ b/namer/curatorsd/src/main/scala/com/medallia/l5d/curatorsd/namer/CuratorSDNamer.scala
@@ -29,12 +29,11 @@ class CuratorSDNamer(zkConnectStr: String, backwardsCompatibility: Option[String
 
   private def getAddress(instances: Iterable[ServiceInstance[ServiceInstanceInfo]], protocol: String): Addr = {
     val addrs = instances
-                  .map(instance => new URL(instance.getUriSpec.build()))
-                  .filter(url => url.getProtocol() == protocol)
-                  .map(url => Address(url.getHost, url.getPort))
-                  .filter()
-                  .toStream
-                  .distinct
+      .map(instance => new URL(instance.getUriSpec.build()))
+      .filter(url => url.getProtocol == protocol)
+      .map(url => Address(url.getHost, url.getPort))
+      .toStream
+      .distinct
     log.info("Binding to addresses %s protocol %s", addrs, protocol)
     val metadata = Addr.Metadata(("ssl", protocol == "https"))
     Addr.Bound(addrs.toSet, metadata)
@@ -49,14 +48,14 @@ class CuratorSDNamer(zkConnectStr: String, backwardsCompatibility: Option[String
 
         log.info(s"Looking up %s, protocol: %s", serviceId, protocol)
 
-        val addrInit = getAddress(serviceDiscoveryInfo.serviceDiscovery.lookupAll(serviceId).asScala)
+        val addrInit = getAddress(serviceDiscoveryInfo.serviceDiscovery.lookupAll(serviceId).asScala, protocol)
         val addrVar = Var.async(addrInit) { update =>
 
           val listener = new ServiceDiscoveryListener {
 
             override def serviceInstancesChanged(): Unit = {
               log.info("Cache changed for %s", serviceName)
-              update() = getAddress(serviceDiscoveryInfo.serviceDiscovery.lookupAll(serviceId).asScala)
+              update() = getAddress(serviceDiscoveryInfo.serviceDiscovery.lookupAll(serviceId).asScala, protocol)
             }
 
           }

--- a/router/http/src/main/scala/io/buoyant/router/http/EnvTenantHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/EnvTenantHostIdentifier.scala
@@ -38,6 +38,8 @@ case class EnvTenantHostIdentifier(
 
   val EnvironmentHeader = "X-Medallia-Rpc-Environment"
 
+  val ProtocolHeader = "X-Medallia-Rpc-Protocol"
+
   private[this] def mkPath(path: Path): Dst.Path =
     Dst.Path(prefix ++ path, baseDtab(), Dtab.local)
 
@@ -45,13 +47,14 @@ case class EnvTenantHostIdentifier(
     val tenant = getHeader(req, TenantHeader).orElse(defaultTenant)
     val environment = getHeader(req, EnvironmentHeader)
     val host = getHeader(req, HostHeader)
+    val protocol = getHeader(req, ProtocolHeader)
 
     if (tenant.isEmpty) {
       Future.value(new UnidentifiedRequest(s"$TenantHeader header is absent"))
     } else if (host.isEmpty) {
       Future.value(new UnidentifiedRequest(s"$HostHeader header is absent"))
     } else {
-      val dst = mkPath(Path.Utf8(environment.getOrElse("_"), tenant.get, host.get))
+      val dst = mkPath(Path.Utf8(environment.getOrElse("_"), tenant.get, host.get, protocol.getOrElse("http")))
       Future.value(new IdentifiedRequest(dst, req))
     }
   }

--- a/router/http/src/main/scala/io/buoyant/router/http/EnvTenantHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/EnvTenantHostIdentifier.scala
@@ -24,6 +24,7 @@ object EnvTenantHostIdentifier {
  *   There's the ability to set a default value in the linkerd configuration (which is used if the header is not sent). That's currently only used
  *   by clients that don't want to inject the header in their clients (e.g. chatgrid)
  *   <li> Host: Required. Service name
+ *   <li> X-Medallia-Rpc-Protocol: Optional (http is default). Which service endpoints should be picked for a given request.
  * </ol>
  */
 case class EnvTenantHostIdentifier(

--- a/router/http/src/main/scala/io/buoyant/router/http/EnvTenantHostIdentifier.scala
+++ b/router/http/src/main/scala/io/buoyant/router/http/EnvTenantHostIdentifier.scala
@@ -21,8 +21,8 @@ object EnvTenantHostIdentifier {
  * <ol>
  *   <li> X-Medallia-Rpc-Environment: Optional. "_" represents a cross environment request. Currently only used for QA Clusters.
  *   <li> X-Medallia-Rpc-Tenant: Required. Tenant for the request.
-  *   There's the ability to set a default value in the linkerd configuration (which is used if the header is not sent). That's currently only used
-  *   by clients that don't want to inject the header in their clients (e.g. chatgrid)
+ *   There's the ability to set a default value in the linkerd configuration (which is used if the header is not sent). That's currently only used
+ *   by clients that don't want to inject the header in their clients (e.g. chatgrid)
  *   <li> Host: Required. Service name
  * </ol>
  */


### PR DESCRIPTION
Currently we don't have a way to select which endpoint to use, and if any https endpoint is present, they will fail.
With this change, there's a new header used to define which kind of endpoints service discovery should use.