### PR TITLE
Custom ResponseClassifier to retry all 502,503,504

### DIFF
--- a/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
+++ b/linkerd/protocol/http/src/main/resources/META-INF/services/io.buoyant.linkerd.ResponseClassifierInitializer
@@ -3,3 +3,4 @@ io.buoyant.linkerd.protocol.http.RetryableIdempotent5XXInitializer
 io.buoyant.linkerd.protocol.http.RetryableRead5XXInitializer
 io.buoyant.linkerd.protocol.http.AllSuccessfulInitializer
 io.buoyant.linkerd.protocol.http.RetryableAll5XXInitializer
+io.buoyant.linkerd.protocol.http.RetryableAllGatewayErrorInitializer

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiers.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiers.scala
@@ -89,6 +89,35 @@ object ResponseClassifiers {
     }
   }
 
+  object GatewayErrorResponses {
+
+    object Failure {
+      def unapply(rsp: Response): Boolean = rsp.status match {
+        case Status.BadGateway | Status.ServiceUnavailable | Status.GatewayTimeout => true
+        case _ => false
+      }
+
+      // There are probably some (linkerd-generated) failures that aren't
+      // really retryable... For now just check if it's a failure.
+      object Retryable {
+        def unapply(rsp: Response): Boolean = Failure.unapply(rsp)
+      }
+    }
+  }
+
+  object RetryableGatewayErrorResult {
+    private[this] val retryableThrow: PartialFunction[Try[Nothing], Boolean] =
+      TimeoutAndWriteExceptionsOnly.orElse(ChannelClosedExceptionsOnly)
+        .orElse(FramingExceptionsOnly)
+        .orElse { case _ => false }
+
+    def unapply(rsp: Try[Any]): Boolean = rsp match {
+      case Return(GatewayErrorResponses.Failure.Retryable()) => true
+      case Throw(e) => retryableThrow(Throw(e))
+      case _ => false
+    }
+  }
+
   /**
    * Classifies 5XX responses as failures. If the method is idempotent
    * (as described by RFC2616), it is classified as retryable.
@@ -105,6 +134,11 @@ object ResponseClassifiers {
   val RetryableAllFailures: ResponseClassifier =
     ResponseClassifier.named("RetryableAllFailures") {
       case ReqRep(Requests.All(), RetryableResult()) => ResponseClass.RetryableFailure
+    }
+
+  val RetryableAllGatewayErrorFailures: ResponseClassifier =
+    ResponseClassifier.named("RetryableAllGatewayErrorFailures") {
+      case ReqRep(Requests.All(), RetryableGatewayErrorResult()) => ResponseClass.RetryableFailure
     }
 
   /**
@@ -170,6 +204,17 @@ class RetryableAll5XXInitializer extends ResponseClassifierInitializer {
 }
 
 object RetryableAll5XXInitializer extends RetryableAll5XXInitializer
+
+class RetryableAllGatewayErrorConfig extends ResponseClassifierConfig {
+  def mk: ResponseClassifier = ResponseClassifiers.RetryableAllGatewayErrorFailures
+}
+
+class RetryableAllGatewayErrorInitializer extends ResponseClassifierInitializer {
+  val configClass = classOf[RetryableAllGatewayErrorConfig]
+  override val configId = "io.l5d.http.retryableAllGatewayError"
+}
+
+object RetryableAllGatewayErrorInitializer extends RetryableAllGatewayErrorInitializer
 
 class RetryableRead5XXConfig extends ResponseClassifierConfig {
   def mk: ResponseClassifier = ResponseClassifiers.RetryableReadFailures

--- a/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiers.scala
+++ b/linkerd/protocol/http/src/main/scala/io/buoyant/linkerd/protocol/http/ResponseClassifiers.scala
@@ -89,6 +89,10 @@ object ResponseClassifiers {
     }
   }
 
+  /**
+   * Matches Gateway error responses (502, 503, 504), which usually are safe
+   * to be retried independently of the request method
+   */
   object GatewayErrorResponses {
 
     object Failure {
@@ -136,6 +140,9 @@ object ResponseClassifiers {
       case ReqRep(Requests.All(), RetryableResult()) => ResponseClass.RetryableFailure
     }
 
+  /**
+   * Classifies 502,503 and 504 responses as retryable failures, for all request methods.
+   */
   val RetryableAllGatewayErrorFailures: ResponseClassifier =
     ResponseClassifier.named("RetryableAllGatewayErrorFailures") {
       case ReqRep(Requests.All(), RetryableGatewayErrorResult()) => ResponseClass.RetryableFailure

--- a/project/Base.scala
+++ b/project/Base.scala
@@ -32,7 +32,7 @@ object Base {
 class Base extends Build {
   import Base._
 
-  val headVersion = "1.5.2-medallia-1.10.0"
+  val headVersion = "1.5.2-medallia-1.11.0"
   val openJdkVersion = "8u151"
   val openJ9Version = "jdk8u162-b12_openj9-0.8.0"
 


### PR DESCRIPTION
New ResponseClassifier to retry all requests (independently of the method) that return 502,503 or 504.

Can be configured like this:
```
routers:
- protocol: http
  label: outgoing
  service:
    responseClassifier:
      kind: io.l5d.http.retryableAllGatewayError #io.l5d.http.retryableRead5XX
```